### PR TITLE
Update for "ifunny-project-id" & other small fixes

### DIFF
--- a/src/objects/Client.js
+++ b/src/objects/Client.js
@@ -28,7 +28,7 @@ class Client extends EventEmitter {
         // read-only implied private data
         this._client_id = 'MsOIJ39Q28'
         this._client_secret = 'PTDc3H8a)Vi=UYap'
-        this._user_agent = 'iFunny/5.43.1(1117828) Android/5.0.2 (samsung; SCH-R530U; samsung)'
+        this._user_agent = 'iFunny/7.7.1(1119745) Android/11 (samsung; GT-N8013; samsung)'
 
         // stored values that methods will update
         this._update = false

--- a/src/objects/Client.js
+++ b/src/objects/Client.js
@@ -431,7 +431,8 @@ class Client extends EventEmitter {
         return (async () => {
             return {
                 'User-Agent': this._user_agent,
-                'Authorization': this._token ? `Bearer ${this._token}` : `Basic ${await this.basic_token}`
+                'Authorization': this._token ? `Bearer ${this._token}` : `Basic ${await this.basic_token}`,
+                'ifunny-project-id': 'iFunny'
             }
         })()
     }

--- a/src/objects/client_proto/PostProto.js
+++ b/src/objects/client_proto/PostProto.js
@@ -12,7 +12,7 @@ const { compose_comment } = require('../../utils/methods')
  * @return {Promise<Object>}                                     API response
  */
 Client.prototype.add_comment_to_post = async function(post, text, attachment, mentions) {
-    let data = compose_comment(text, attachment, mentions)
+    let data = await compose_comment(text, attachment, mentions)
 
     let response = await axios({
         method: 'post',

--- a/src/utils/methods.js
+++ b/src/utils/methods.js
@@ -116,5 +116,6 @@ module.exports = {
     paginated_data: paginated_data,
     paginated_generator: paginated_generator,
     determine_mime: determine_mime,
-    sleep: sleep
+    sleep: sleep,
+    compose_comment: compose_comment
 }

--- a/src/utils/methods.js
+++ b/src/utils/methods.js
@@ -78,6 +78,7 @@ async function compose_comment(text, attachment, mentions) {
 
     if (text) {
         data.text = text
+        data.from = 'prof'
     }
 
     if (attachment) {


### PR DESCRIPTION
iFunny now requires header `ifunny-project-id` for all requests.
Fixed and re-implemented function `add_comment_to_post`.
Changed `Client._user_agent`.